### PR TITLE
Vertical Button fixes

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -17,8 +17,11 @@ class Notifier {
     const options = Object.assign({}, data)
     const size = electron.screen.getPrimaryDisplay().workAreaSize
     let verticalSpace = 0
-    if (options.vertical && options.buttons) {
-      verticalSpace = Math.max(options.buttons.length * 40, 80)
+    if (options.vertical && options.buttons && options.buttons.length) {
+      verticalSpace = Math.min(options.buttons.length * 40, 80)
+    }
+    else {
+      options.vertical = false;
     }
     const notificationWindow = new this.BrowserWindow({
       width: 440,


### PR DESCRIPTION
Fix vertical space calculation. It should be capped at 80px, not floored to 80px.
Fix bug where vertical style is used with no buttons, resulting a broken border style.
